### PR TITLE
Correct usec calculation for tsresol other than 6.

### DIFF
--- a/scapy/utils.py
+++ b/scapy/utils.py
@@ -733,9 +733,9 @@ class _RawPcapNGReader:
 
     def parse_usec(self, t):
         if self.tsresol & 0b10000000:
-            return t & (1 << self.tsresol) - 1
+            return (t & (1 << self.tsresol) - 1) / pow(10, self.tsresol - 6)
         else:
-            return t % pow(10, self.tsresol)
+            return (t % pow(10, self.tsresol)) / pow(10, self.tsresol - 6)
 
     def parse_options(self, opt):
         buf = opt


### PR DESCRIPTION
`parse_usec` returns the `self.tsresol` least significant integers of the passed time t. The result is the interpreted as microseconds. This is only true, if `self.tsresol` equals 6, otherwise the return value will be errouneously interpreted as microseconds. If, for example, `tsresol` is 9, then an 8-digit number is returned that represents a timestamp in nanoseconds, but is then interpreted as microseconds. This happens for every `tsresol` other than 6.

This pull request normalizes the return value of `parse_usec` by `pow(10, self.tsresol-6)`, ensuring that the portion of the timestamp smaller than a second is correctly returned in microsecond format. Thus, a nanosecond (`tsresol=9`) timescale will have 3 decimal places, while a millisecond timescale (`tsresol=3`) will append three zeros.
